### PR TITLE
fix(android): replace removed jcenter() with mavenCentral()

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -4,7 +4,7 @@ version '1.0'
 buildscript {
     repositories {
         google()
-        jcenter()
+        mavenCentral()
     }
 
     dependencies {
@@ -15,7 +15,7 @@ buildscript {
 rootProject.allprojects {
     repositories {
         google()
-        jcenter()
+        mavenCentral()
     }
 }
 


### PR DESCRIPTION
## Problem

`android/build.gradle` declares `jcenter()` in both the `buildscript` and `allprojects` repository blocks. **Gradle 9 removed `jcenter()`** (it was only deprecated through Gradle 8.x), so any project that evaluates this plugin under Gradle 9 fails:

```
* What went wrong:
A problem occurred evaluating project ':flutter_system_proxy'.
> Could not find method jcenter() for arguments [] on repository container ...
```

This surfaces as soon as a consuming app upgrades its Android toolchain to Gradle 9 (e.g. via a newer Flutter SDK that regenerates the Gradle wrapper).

## Fix

Replace both `jcenter()` calls with `mavenCentral()`. JCenter has been sunset (read-only since early 2022), and the artifacts these blocks need are available on Maven Central, so this is a safe, behaviour-preserving swap that also works on Gradle 8.x.

```diff
     repositories {
         google()
-        jcenter()
+        mavenCentral()
     }
```

No other changes.